### PR TITLE
Fixed title: Centos -> Epel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-yum-centos Cookbook
+yum-epel Cookbook
 ============
 
 The yum-epel cookbook takes over management of the default


### PR DESCRIPTION
The title of the README was wrong and said "yum-centos" instead of "yum-epel".

Obvious fix.
