### PR TITLE
[COOK-4292]

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,7 @@
     sslclientkey node['yum'][repo]['sslclientkey']
     sslverify node['yum'][repo]['sslverify']
     timeout node['yum'][repo]['timeout']
+    only_if { node['yum'][repo]['enabled'] }
     action :create
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -4,6 +4,43 @@ describe 'yum-epel::default' do
   context 'yum-epel::default uses default attributes' do
     let(:chef_run) { ChefSpec::Runner.new(:step_into => ['yum_repository']).converge(described_recipe) }
 
+    it 'creates yum_repository[epel]' do
+      expect(chef_run).to create_yum_repository('epel') 
+    end
+
+    it 'steps into yum_repository and creats template[/etc/yum.repos.d/epel.repo]' do
+      expect(chef_run).to render_file('/etc/yum.repos.d/epel.repo')
+    end
+
+    %w{
+      epel-debuginfo
+      epel-source
+      epel-testing
+      epel-testing-debuginfo
+      epel-testing-source
+      }.each do |repo|
+      it "creates yum_repository[#{repo}]" do
+        expect(chef_run).to_not create_yum_repository(repo)
+      end
+
+      it "steps into yum_repository and creates template[/etc/yum.repos.d/#{repo}.repo]" do
+        expect(chef_run).to_not render_file("/etc/yum.repos.d/#{repo}.repo")
+      end
+    end
+  end
+
+  context 'yum-epel::default with all repos enabled' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(:step_into => ['yum_repository']) do |node|
+        %w{
+          epel epel-debuginfo epel-source epel-testing
+          epel-testing-debuginfo epel-testing-source
+          }.each do |repo|
+            node.normal['yum'][repo]['enabled'] = true
+          end
+      end.converge(described_recipe)
+    end
+
     %w{
       epel
       epel-debuginfo
@@ -20,6 +57,5 @@ describe 'yum-epel::default' do
         expect(chef_run).to render_file("/etc/yum.repos.d/#{repo}.repo")
       end
     end
-
   end
 end


### PR DESCRIPTION
yum-epel dumps out a bunch of extra repositories I would not ever
want/need on production systems, even though all of those are disabled
by default.

As a result, the provider in yum cookbook runs makecache against them, even
though these are disabled, and significantly slows down convergence on
everything that depends on EPEL. Its about three times slower than just
converging the one single epel repository.  It may not be a big deal to
some, but becomes a huge time sink for anyone doing iterative
development in Test Kitchen with many EPEL dependencies.

Either, don't render a template for a disabled repo, or add an
node.yum.epel.repositories array to let users override unwanted
templates.
