### PR TITLE
Add support for CentOS Stream 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           - 'amazonlinux-2'
           - 'centos-7'
           - 'centos-8'
+          - 'centos-stream-8'
           - 'oraclelinux-7'
           - 'oraclelinux-8'
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
+- Add support for CentOS Stream 8
+
 ## 4.1.4 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/README.md
+++ b/README.md
@@ -6,29 +6,35 @@
 [![OpenCollective](https://opencollective.com/sous-chefs/sponsors/badge.svg)](#sponsors)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Extra Packages for Enterprise Linux (or EPEL) is a Fedora Special Interest Group that creates, maintains, and manages a high quality set of additional packages for Enterprise Linux, including, but not limited to, Red Hat Enterprise Linux (RHEL), CentOS and Scientific Linux (SL), Oracle Linux (OL).
+Extra Packages for Enterprise Linux (or EPEL) is a Fedora Special Interest Group that creates, maintains, and manages a high quality set of additional packages for Enterprise Linux, including, but not limited to, Red Hat Enterprise Linux (RHEL), CentOS , CentOS Stream and Scientific Linux (SL), Oracle Linux (OL).
 
 The yum-epel cookbook takes over management of the default repositoryids shipped with epel-release.
 
 Below is a table showing which repositoryids we manage that are shipped by default via the epel-release package:
 
-| Repo ID                        | EL 7             | EL 8             |
-| ------------------------------ | :--------------: | :--------------: |
-| epel                           |:heavy_check_mark:|:heavy_check_mark:|
-| epel-debuginfo                 |:heavy_check_mark:|:heavy_check_mark:|
-| epel-modular                   |       :x:        |:heavy_check_mark:|
-| epel-modular-debuginfo         |       :x:        |:heavy_check_mark:|
-| epel-modular-source            |       :x:        |:heavy_check_mark:|
-| epel-playground                |       :x:        |:heavy_check_mark:|
-| epel-playground-debuginfo      |       :x:        |:heavy_check_mark:|
-| epel-playground-source         |       :x:        |:heavy_check_mark:|
-| epel-source                    |:heavy_check_mark:|:heavy_check_mark:|
-| epel-testing                   |:heavy_check_mark:|:heavy_check_mark:|
-| epel-testing-debuginfo         |:heavy_check_mark:|:heavy_check_mark:|
-| epel-testing-modular           |       :x:        |:heavy_check_mark:|
-| epel-testing-modular-debuginfo |       :x:        |:heavy_check_mark:|
-| epel-testing-modular-source    |       :x:        |:heavy_check_mark:|
-| epel-testing-source            |:heavy_check_mark:|:heavy_check_mark:|
+| Repo ID                        | EL 7             | EL 8             | CentOS Stream 8  |
+| ------------------------------ | :--------------: | :--------------: | :--------------: |
+| epel                           |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
+| epel-debuginfo                 |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
+| epel-modular                   |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-modular-debuginfo         |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-modular-source            |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-next                      |       :x:        |       :x:        |:heavy_check_mark:|
+| epel-next-debuginfo            |       :x:        |       :x:        |:heavy_check_mark:|
+| epel-next-source               |       :x:        |       :x:        |:heavy_check_mark:|
+| epel-next-testing              |       :x:        |       :x:        |:heavy_check_mark:|
+| epel-next-testing-debug        |       :x:        |       :x:        |:heavy_check_mark:|
+| epel-next-testing-source       |       :x:        |       :x:        |:heavy_check_mark:|
+| epel-playground                |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-playground-debuginfo      |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-playground-source         |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-source                    |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
+| epel-testing                   |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
+| epel-testing-debuginfo         |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
+| epel-testing-modular           |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-testing-modular-debuginfo |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-testing-modular-source    |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
+| epel-testing-source            |:heavy_check_mark:|:heavy_check_mark:|       :x:        |
 
 ## Requirements
 
@@ -54,7 +60,7 @@ See individual repository attribute files for defaults.
 
 ## Recipes
 
-- `yum-epel::default` Generates `yum_repository` configs for the standard EPEL repositories. By default the `epel` repository is enabled.
+- `yum-epel::default` Generates `yum_repository` configs for the standard EPEL repositories. By default the `epel` repository is enabled unless on CentOS Stream. By default the `epel-next` repository is enabled on CentOS Stream and the `epel` repository is disabled.
 
 ## Usage Example
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,24 +1,7 @@
 default['yum-epel']['repos'] =
   value_for_platform(
     %w(redhat centos oracle) => {
-      '>= 8.0' =>
-        %w(
-          epel
-          epel-debuginfo
-          epel-modular
-          epel-modular-debuginfo
-          epel-modular-source
-          epel-playground
-          epel-playground-debuginfo
-          epel-playground-source
-          epel-source
-          epel-testing
-          epel-testing-debuginfo
-          epel-testing-modular
-          epel-testing-modular-debuginfo
-          epel-testing-modular-source
-          epel-testing-source
-        ),
+      '>= 8.0' => centos_8_repos,
       '~> 7.0' =>
         %w(
           epel

--- a/attributes/epel-next-debuginfo.rb
+++ b/attributes/epel-next-debuginfo.rb
@@ -1,0 +1,11 @@
+default['yum']['epel-next-debuginfo']['repositoryid'] = 'epel-next-debuginfo'
+default['yum']['epel-next-debuginfo']['description'] =
+  "Extra Packages for #{node['platform_version'].to_i} - $basearch - Next - Debug"
+default['yum']['epel-next-debuginfo']['mirrorlist'] =
+  "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-debug-#{node['platform_version'].to_i}&arch=$basearch"
+default['yum']['epel-next-debuginfo']['gpgkey'] =
+  "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+default['yum']['epel-next-debuginfo']['gpgcheck'] = true
+default['yum']['epel-next-debuginfo']['enabled'] = false
+default['yum']['epel-next-debuginfo']['managed'] = false
+default['yum']['epel-next-debuginfo']['make_cache'] = true

--- a/attributes/epel-next-source.rb
+++ b/attributes/epel-next-source.rb
@@ -1,0 +1,11 @@
+default['yum']['epel-next-source']['repositoryid'] = 'epel-next-source'
+default['yum']['epel-next-source']['description'] =
+  "Extra Packages for #{node['platform_version'].to_i} $basearch - Next -Source"
+default['yum']['epel-next-source']['mirrorlist'] =
+  "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-source-#{node['platform_version'].to_i}&arch=$basearch"
+default['yum']['epel-next-source']['gpgkey'] =
+  "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+default['yum']['epel-next-source']['gpgcheck'] = true
+default['yum']['epel-next-source']['enabled'] = false
+default['yum']['epel-next-source']['managed'] = false
+default['yum']['epel-next-source']['make_cache'] = true

--- a/attributes/epel-next-testing-debuginfo.rb
+++ b/attributes/epel-next-testing-debuginfo.rb
@@ -1,0 +1,11 @@
+default['yum']['epel-next-testing-debuginfo']['repositoryid'] = 'epel-next-testing-debuginfo'
+default['yum']['epel-next-testing-debuginfo']['description'] =
+  "Extra Packages for #{node['platform_version'].to_i} - $basearch - Next - Testing Debug"
+default['yum']['epel-next-testing-debuginfo']['mirrorlist'] =
+  "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-testing-next-debug-#{node['platform_version'].to_i}&arch=$basearch"
+default['yum']['epel-next-testing-debuginfo']['gpgkey'] =
+  "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+default['yum']['epel-next-testing-debuginfo']['gpgcheck'] = true
+default['yum']['epel-next-testing-debuginfo']['enabled'] = false
+default['yum']['epel-next-testing-debuginfo']['managed'] = false
+default['yum']['epel-next-testing-debuginfo']['make_cache'] = true

--- a/attributes/epel-next-testing-source.rb
+++ b/attributes/epel-next-testing-source.rb
@@ -1,0 +1,11 @@
+default['yum']['epel-next-testing-source']['repositoryid'] = 'epel-next-testing-source'
+default['yum']['epel-next-testing-source']['description'] =
+  "Extra Packages for #{node['platform_version'].to_i} - $basearch - Next - Testing Source"
+default['yum']['epel-next-testing-source']['mirrorlist'] =
+  "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{node['platform_version'].to_i}&arch=$basearch"
+default['yum']['epel-next-testing-source']['gpgkey'] =
+  "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+default['yum']['epel-next-testing-source']['gpgcheck'] = true
+default['yum']['epel-next-testing-source']['enabled'] = false
+default['yum']['epel-next-testing-source']['managed'] = false
+default['yum']['epel-next-testing-source']['make_cache'] = true

--- a/attributes/epel-next-testing.rb
+++ b/attributes/epel-next-testing.rb
@@ -1,0 +1,11 @@
+default['yum']['epel-next-testing']['repositoryid'] = 'epel-next-testing'
+default['yum']['epel-next-testing']['description'] =
+  "Extra Packages for #{node['platform_version'].to_i} - $basearch - Next - Testing"
+default['yum']['epel-next-testing']['mirrorlist'] =
+  "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-testing-next-#{node['platform_version'].to_i}&arch=$basearch"
+default['yum']['epel-next-testing']['gpgkey'] =
+  "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+default['yum']['epel-next-testing']['gpgcheck'] = true
+default['yum']['epel-next-testing']['enabled'] = false
+default['yum']['epel-next-testing']['managed'] = false
+default['yum']['epel-next-testing']['make_cache'] = true

--- a/attributes/epel-next.rb
+++ b/attributes/epel-next.rb
@@ -1,0 +1,10 @@
+default['yum']['epel-next']['repositoryid'] = 'epel-next'
+default['yum']['epel-next']['gpgcheck'] = true
+default['yum']['epel-next']['description'] = 'Extra Packages for $releasever - Next - $basearch'
+default['yum']['epel-next']['mirrorlist'] =
+  "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-#{node['platform_version'].to_i}&arch=$basearch"
+default['yum']['epel-next']['gpgkey'] =
+  "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+default['yum']['epel-next']['enabled'] = true
+default['yum']['epel-next']['managed'] = true
+default['yum']['epel-next']['make_cache'] = true

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -18,6 +18,6 @@ else
     default['yum']['epel']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
   end
 end
-default['yum']['epel']['enabled'] = true
+default['yum']['epel']['enabled'] = yum_epel_centos_stream? ? false : true
 default['yum']['epel']['managed'] = true
 default['yum']['epel']['make_cache'] = true

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -30,6 +30,11 @@ platforms:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: centos-stream-8
+    driver:
+      image: dokken/centos-stream-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: oraclelinux-7
     driver:
       image: dokken/oraclelinux-7

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,6 +13,7 @@ platforms:
   - name: amazonlinux-2
   - name: centos-7
   - name: centos-8
+  - name: centos-stream-8
   - name: oraclelinux-7
   - name: oraclelinux-8
 
@@ -35,6 +36,24 @@ suites:
           managed: true
           enabled: true
         epel-modular-source:
+          managed: true
+          enabled: true
+        epel-next:
+          managed: true
+          enabled: true
+        epel-next-debuginfo:
+          managed: true
+          enabled: true
+        epel-next-source:
+          managed: true
+          enabled: true
+        epel-next-testing:
+          managed: true
+          enabled: true
+        epel-next-testing-debuginfo:
+          managed: true
+          enabled: true
+        epel-next-testing-source:
           managed: true
           enabled: true
         epel-playground:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,53 @@
+module YumEpel
+  module Cookbook
+    module Helpers
+      def centos_8_repos
+        if yum_epel_centos_stream?
+          %w(
+            epel-modular
+            epel-modular-debuginfo
+            epel-modular-source
+            epel-next
+            epel-next-debuginfo
+            epel-next-source
+            epel-next-testing
+            epel-next-testing-debuginfo
+            epel-next-testing-source
+            epel-playground
+            epel-playground-debuginfo
+            epel-playground-source
+            epel-testing-modular
+            epel-testing-modular-debuginfo
+            epel-testing-modular-source
+          )
+        else
+          %w(
+            epel
+            epel-debuginfo
+            epel-modular
+            epel-modular-debuginfo
+            epel-modular-source
+            epel-playground
+            epel-playground-debuginfo
+            epel-playground-source
+            epel-source
+            epel-testing
+            epel-testing-debuginfo
+            epel-testing-modular
+            epel-testing-modular-debuginfo
+            epel-testing-modular-source
+            epel-testing-source
+          )
+        end
+      end
+
+      private
+
+      def yum_epel_centos_stream?
+        respond_to?(:centos_stream_platform?) && centos_stream_platform?
+      end
+    end
+  end
+end
+# Needed to used in attributes/
+Chef::Node.include ::YumEpel::Cookbook::Helpers

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -32,13 +32,39 @@ describe 'yum-epel::default' do
   # That equals release7 on RHEL 7 and EPEL repo doesn't return anything for that so please
   # leave node['platform_version'].to_i
 
-  context 'on RHEL 7' do
+  context 'on CentOS 7' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '7').converge('yum-epel::default')
     end
 
-    it 'creates epel repo with proper version string' do
+    it do
       expect(chef_run).to create_yum_repository('epel').with(mirrorlist: 'https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch')
+    end
+  end
+
+  context 'on CentOS 8' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '8').converge('yum-epel::default')
+    end
+
+    it do
+      expect(chef_run).to create_yum_repository('epel').with(mirrorlist: 'https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=$basearch')
+    end
+  end
+
+  context 'on CentOS Stream 8' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '8') do |node|
+        node.automatic['os_release']['name'] = 'CentOS Stream'
+      end.converge('yum-epel::default')
+    end
+
+    it do
+      expect(chef_run).to create_yum_repository('epel-next').with(mirrorlist: 'https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-8&arch=$basearch')
+    end
+
+    it do
+      expect(chef_run).to_not create_yum_repository('epel')
     end
   end
 
@@ -47,7 +73,7 @@ describe 'yum-epel::default' do
       ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge('yum-epel::default')
     end
 
-    it 'creates epel repo with proper version string' do
+    it do
       expect(chef_run).to create_yum_repository('epel').with(mirrorlist: 'https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch')
     end
   end

--- a/test/integration/all/all_spec.rb
+++ b/test/integration/all/all_spec.rb
@@ -1,41 +1,51 @@
 os_release = os.name == 'amazon' ? 7 : os.release.to_i
-infra = os.name == 'oracle' ? '$infra' : 'container'
+stream = file('/etc/os-release').content.match?('Stream')
+infra =
+  if os.name == 'oracle'
+    '$infra'
+  elsif stream
+    'stock'
+  else
+    'container'
+  end
 content = os.name == 'oracle' ? '$contentdir' : 'centos'
 
-describe yum.repo 'epel' do
-  it { should exist }
-  it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{os_release}&arch=x86_64" }
-end
+unless stream
+  describe yum.repo 'epel' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{os_release}&arch=x86_64" }
+  end
 
-describe yum.repo 'epel-debuginfo' do
-  it { should exist }
-  it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-#{os_release}&arch=x86_64" }
-end
+  describe yum.repo 'epel-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-#{os_release}&arch=x86_64" }
+  end
 
-describe yum.repo 'epel-source' do
-  it { should exist }
-  it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-#{os_release}&arch=x86_64" }
-end
+  describe yum.repo 'epel-source' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-#{os_release}&arch=x86_64" }
+  end
 
-describe yum.repo 'epel-testing' do
-  it { should exist }
-  it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel#{os_release}&arch=x86_64" }
-end
+  describe yum.repo 'epel-testing' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel#{os_release}&arch=x86_64" }
+  end
 
-describe yum.repo 'epel-testing-debuginfo' do
-  it { should exist }
-  it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel#{os_release}&arch=x86_64" }
-end
+  describe yum.repo 'epel-testing-debuginfo' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel#{os_release}&arch=x86_64" }
+  end
 
-describe yum.repo 'epel-testing-source' do
-  it { should exist }
-  it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{os_release}&arch=x86_64" }
+  describe yum.repo 'epel-testing-source' do
+    it { should exist }
+    it { should be_enabled }
+    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{os_release}&arch=x86_64" }
+  end
 end
 
 if os_release >= 8
@@ -91,6 +101,58 @@ if os_release >= 8
     it { should exist }
     it { should be_enabled }
     its('mirrors') { should cmp "https://mirrors.fedoraproject.org/metalink?repo=testing-modular-source-epel8&arch=x86_64&infra=#{infra}&content=#{content}" }
+  end
+
+  if stream
+    describe yum.repo 'epel-next' do
+      it { should exist }
+      it { should be_enabled }
+      its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-#{os_release}&arch=x86_64" }
+    end
+
+    describe yum.repo 'epel-next-debuginfo' do
+      it { should exist }
+      it { should be_enabled }
+      its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-debug-#{os_release}&arch=x86_64" }
+    end
+
+    describe yum.repo 'epel-next-source' do
+      it { should exist }
+      it { should be_enabled }
+      its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-source-#{os_release}&arch=x86_64" }
+    end
+
+    describe yum.repo 'epel-next-testing' do
+      it { should exist }
+      it { should be_enabled }
+      its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-testing-next-#{os_release}&arch=x86_64" }
+    end
+
+    describe yum.repo 'epel-next-testing-debuginfo' do
+      it { should exist }
+      it { should be_enabled }
+      its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-testing-next-debug-#{os_release}&arch=x86_64" }
+    end
+
+    describe yum.repo 'epel-next-testing-source' do
+      it { should exist }
+      it { should be_enabled }
+      its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{os_release}&arch=x86_64" }
+    end
+
+    %w(
+      epel
+      epel-debuginfo
+      epel-source
+      epel-testing
+      epel-testing-debuginfo
+      epel-testing-source
+    ).each do |repo|
+      describe yum.repo repo do
+        it { should_not exist }
+        it { should_not be_enabled }
+      end
+    end
   end
 else
   %w(

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,13 +1,26 @@
 os_release = os.name == 'amazon' ? '7' : os.release.to_i
+stream = file('/etc/os-release').content.match?('Stream')
 
-describe yum.repo 'epel' do
+epel_repo = stream ? 'epel-next' : 'epel'
+
+describe yum.repo epel_repo do
   it { should exist }
   it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{os_release}&arch=x86_64" }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=#{epel_repo}-#{os_release}&arch=x86_64" }
 end
+
+describe yum.repo 'epel' do
+  it { should_not exist }
+  it { should_not be_enabled }
+end if stream
 
 %w(
   epel-debuginfo
+  epel-next-debuginfo
+  epel-next-source
+  epel-next-testing
+  epel-next-testing-debuginfo
+  epel-next-testing-source
   epel-source
   epel-testing
   epel-testing-debuginfo


### PR DESCRIPTION
CentOS Stream needs to use epel-next and _not_ epel. This provides proper support for this.

Signed-off-by: Lance Albertson <lance@osuosl.org>
