### PR TITLE
Restore epel and epel-debuginfo into the default list for Stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
+- Add epel and epel-debuginfo repos by default for CentOS Streams
+
 ## 4.2.0 - *2021-11-02*
 
 - Add support for CentOS Stream 8

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -18,6 +18,6 @@ else
     default['yum']['epel']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
   end
 end
-default['yum']['epel']['enabled'] = yum_epel_centos_stream? ? false : true
+default['yum']['epel']['enabled'] = true
 default['yum']['epel']['managed'] = true
 default['yum']['epel']['make_cache'] = true

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -2,43 +2,36 @@ module YumEpel
   module Cookbook
     module Helpers
       def centos_8_repos
-        if yum_epel_centos_stream?
+        repos = %w(
+          epel
+          epel-debuginfo
+          epel-modular
+          epel-modular-debuginfo
+          epel-modular-source
+          epel-playground
+          epel-playground-debuginfo
+          epel-playground-source
+          epel-source
+          epel-testing
+          epel-testing-debuginfo
+          epel-testing-modular
+          epel-testing-modular-debuginfo
+          epel-testing-modular-source
+          epel-testing-source
+        )
+
+        repos.concat(
           %w(
-            epel-modular
-            epel-modular-debuginfo
-            epel-modular-source
             epel-next
             epel-next-debuginfo
             epel-next-source
             epel-next-testing
             epel-next-testing-debuginfo
             epel-next-testing-source
-            epel-playground
-            epel-playground-debuginfo
-            epel-playground-source
-            epel-testing-modular
-            epel-testing-modular-debuginfo
-            epel-testing-modular-source
           )
-        else
-          %w(
-            epel
-            epel-debuginfo
-            epel-modular
-            epel-modular-debuginfo
-            epel-modular-source
-            epel-playground
-            epel-playground-debuginfo
-            epel-playground-source
-            epel-source
-            epel-testing
-            epel-testing-debuginfo
-            epel-testing-modular
-            epel-testing-modular-debuginfo
-            epel-testing-modular-source
-            epel-testing-source
-          )
-        end
+        ) if yum_epel_centos_stream?
+
+        repos
       end
 
       private

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -64,7 +64,7 @@ describe 'yum-epel::default' do
     end
 
     it do
-      expect(chef_run).to_not create_yum_repository('epel')
+      expect(chef_run).to create_yum_repository('epel')
     end
   end
 

--- a/test/integration/all/all_spec.rb
+++ b/test/integration/all/all_spec.rb
@@ -10,42 +10,40 @@ infra =
   end
 content = os.name == 'oracle' ? '$contentdir' : 'centos'
 
-unless stream
-  describe yum.repo 'epel' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{os_release}&arch=x86_64" }
-  end
+describe yum.repo 'epel' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{os_release}&arch=x86_64" }
+end
 
-  describe yum.repo 'epel-debuginfo' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-#{os_release}&arch=x86_64" }
-  end
+describe yum.repo 'epel-debuginfo' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-#{os_release}&arch=x86_64" }
+end
 
-  describe yum.repo 'epel-source' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-#{os_release}&arch=x86_64" }
-  end
+describe yum.repo 'epel-source' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-#{os_release}&arch=x86_64" }
+end
 
-  describe yum.repo 'epel-testing' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel#{os_release}&arch=x86_64" }
-  end
+describe yum.repo 'epel-testing' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel#{os_release}&arch=x86_64" }
+end
 
-  describe yum.repo 'epel-testing-debuginfo' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel#{os_release}&arch=x86_64" }
-  end
+describe yum.repo 'epel-testing-debuginfo' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel#{os_release}&arch=x86_64" }
+end
 
-  describe yum.repo 'epel-testing-source' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{os_release}&arch=x86_64" }
-  end
+describe yum.repo 'epel-testing-source' do
+  it { should exist }
+  it { should be_enabled }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{os_release}&arch=x86_64" }
 end
 
 if os_release >= 8
@@ -138,20 +136,6 @@ if os_release >= 8
       it { should exist }
       it { should be_enabled }
       its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{os_release}&arch=x86_64" }
-    end
-
-    %w(
-      epel
-      epel-debuginfo
-      epel-source
-      epel-testing
-      epel-testing-debuginfo
-      epel-testing-source
-    ).each do |repo|
-      describe yum.repo repo do
-        it { should_not exist }
-        it { should_not be_enabled }
-      end
     end
   end
 else

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,17 +1,15 @@
 os_release = os.name == 'amazon' ? '7' : os.release.to_i
 stream = file('/etc/os-release').content.match?('Stream')
 
-epel_repo = stream ? 'epel-next' : 'epel'
-
-describe yum.repo epel_repo do
+describe yum.repo 'epel' do
   it { should exist }
   it { should be_enabled }
-  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=#{epel_repo}-#{os_release}&arch=x86_64" }
+  its('mirrors') { should cmp "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{os_release}&arch=x86_64" }
 end
 
-describe yum.repo 'epel' do
-  it { should_not exist }
-  it { should_not be_enabled }
+describe yum.repo 'epel-next' do
+  it { should exist }
+  it { should be_enabled }
 end if stream
 
 %w(


### PR DESCRIPTION
# Description

Restore epel and epel-debuginfo into the default list for Stream

## Issues Resolved

- n/a

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
