### PR TITLE
Add support for Rocky Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
+- Allow the cookbook to install EPEL on Rocky Linux
+
 ## 4.2.3 - *2021-11-03*
 
 - Rename helper method to `epel_8_repos` to not conflict with yum-centos

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['yum-epel']['repos'] =
   value_for_platform(
-    %w(redhat centos oracle) => {
+    %w(redhat centos oracle rocky) => {
       '>= 8.0' => epel_8_repos,
       '~> 7.0' =>
         %w(

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -68,6 +68,16 @@ describe 'yum-epel::default' do
     end
   end
 
+  context 'on Rocky Linux 8' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'rocky', version: '8').converge('yum-epel::default')
+    end
+
+    it do
+      expect(chef_run).to create_yum_repository('epel').with(mirrorlist: 'https://mirrors.fedoraproject.org/mirrorlist?repo=epel-8&arch=$basearch')
+    end
+  end
+  
   context 'on Amazon 2' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'amazon', version: '2').converge('yum-epel::default')


### PR DESCRIPTION
# Description

Adds `rocky` as a platform where EPEL8 repos are installed.

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
