### PR TITLE
Remove epel-playground per upstream removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
+- Remove epel-playground per upstream removal
+
 ## 4.4.1 - *2022-02-02*
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow

--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ Below is a table showing which repositoryids we manage that are shipped by defau
 | epel-next-testing              |       :x:        |       :x:        |:heavy_check_mark:|
 | epel-next-testing-debug        |       :x:        |       :x:        |:heavy_check_mark:|
 | epel-next-testing-source       |       :x:        |       :x:        |:heavy_check_mark:|
-| epel-playground                |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
-| epel-playground-debuginfo      |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
-| epel-playground-source         |       :x:        |:heavy_check_mark:|:heavy_check_mark:|
 | epel-source                    |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 | epel-testing                   |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
 | epel-testing-debuginfo         |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|

--- a/attributes/epel-playground-debuginfo.rb
+++ b/attributes/epel-playground-debuginfo.rb
@@ -1,8 +1,0 @@
-default['yum']['epel-playground-debuginfo']['repositoryid'] = 'epel-playground-debuginfo'
-default['yum']['epel-playground-debuginfo']['description'] = 'Extra Packages for Enterprise Linux $releasever - Playground - $basearch - Debug'
-default['yum']['epel-playground-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=playground-debug-epel$releasever&arch=$basearch&infra=$infra&content=$contentdir'
-default['yum']['epel-playground-debuginfo']['gpgkey'] = 'https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8'
-default['yum']['epel-playground-debuginfo']['gpgcheck'] = true
-default['yum']['epel-playground-debuginfo']['enabled'] = false
-default['yum']['epel-playground-debuginfo']['managed'] = false
-default['yum']['epel-playground-debuginfo']['make_cache'] = true

--- a/attributes/epel-playground-source.rb
+++ b/attributes/epel-playground-source.rb
@@ -1,8 +1,0 @@
-default['yum']['epel-playground-source']['repositoryid'] = 'epel-playground-source'
-default['yum']['epel-playground-source']['description'] = 'Extra Packages for Enterprise Linux $releasever - Playground - $basearch - Source'
-default['yum']['epel-playground-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=playground-source-epel$releasever&arch=$basearch&infra=$infra&content=$contentdir'
-default['yum']['epel-playground-source']['gpgkey'] = 'https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8'
-default['yum']['epel-playground-source']['gpgcheck'] = true
-default['yum']['epel-playground-source']['enabled'] = false
-default['yum']['epel-playground-source']['managed'] = false
-default['yum']['epel-playground-source']['make_cache'] = true

--- a/attributes/epel-playground.rb
+++ b/attributes/epel-playground.rb
@@ -1,8 +1,0 @@
-default['yum']['epel-playground']['repositoryid'] = 'epel-playground'
-default['yum']['epel-playground']['description'] = 'Extra Packages for Enterprise Linux $releasever - Playground - $basearch'
-default['yum']['epel-playground']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=playground-epel$releasever&arch=$basearch&infra=$infra&content=$contentdir'
-default['yum']['epel-playground']['gpgkey'] = 'https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8'
-default['yum']['epel-playground']['gpgcheck'] = true
-default['yum']['epel-playground']['enabled'] = false
-default['yum']['epel-playground']['managed'] = false
-default['yum']['epel-playground']['make_cache'] = true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -57,15 +57,6 @@ suites:
         epel-next-testing-source:
           managed: true
           enabled: true
-        epel-playground:
-          managed: true
-          enabled: true
-        epel-playground-debuginfo:
-          managed: true
-          enabled: true
-        epel-playground-source:
-          managed: true
-          enabled: true
         epel-source:
           managed: true
           enabled: true

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,9 +8,6 @@ module YumEpel
           epel-modular
           epel-modular-debuginfo
           epel-modular-source
-          epel-playground
-          epel-playground-debuginfo
-          epel-playground-source
           epel-source
           epel-testing
           epel-testing-debuginfo

--- a/test/integration/all/all_spec.rb
+++ b/test/integration/all/all_spec.rb
@@ -73,24 +73,6 @@ if os_release >= 8
     its('mirrors') { should cmp "https://mirrors.fedoraproject.org/metalink?repo=epel-modular-source-8&arch=x86_64&infra=#{infra}&content=#{content}" }
   end
 
-  describe yum.repo 'epel-playground' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/metalink?repo=playground-epel8&arch=x86_64&infra=#{infra}&content=#{content}" }
-  end
-
-  describe yum.repo 'epel-playground-debuginfo' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/metalink?repo=playground-debug-epel8&arch=x86_64&infra=#{infra}&content=#{content}" }
-  end
-
-  describe yum.repo 'epel-playground-source' do
-    it { should exist }
-    it { should be_enabled }
-    its('mirrors') { should cmp "https://mirrors.fedoraproject.org/metalink?repo=playground-source-epel8&arch=x86_64&infra=#{infra}&content=#{content}" }
-  end
-
   describe yum.repo 'epel-testing-modular' do
     it { should exist }
     it { should be_enabled }
@@ -151,9 +133,6 @@ else
     epel-modular
     epel-modular-debuginfo
     epel-modular-source
-    epel-playground
-    epel-playground-debuginfo
-    epel-playground-source
     epel-testing-modular
     epel-testing-modular-debuginfo
     epel-testing-modular-source


### PR DESCRIPTION
The epel-playground is being removed/retired upstream [1] and thus we should remove it from here as well since the repo will be removed from mirrors soon.

[1] https://lists.fedoraproject.org/archives/list/epel-devel@lists.fedoraproject.org/thread/DUBDX55GLCIRVHK7CEDOXILAYCXAHQ73/

Signed-off-by: Lance Albertson <lance@osuosl.org>
