### PR TITLE
Amazon Linux 2023 does not officially support EPEL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
-- Amazon Linux 2023 does not officially support EPEL
+- Disable EPEL on Amazon Linux 2023 as it isn't officially supported
 
 ## 5.0.8 - *2024-05-02*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
+- Amazon Linux 2023 does not officially support EPEL nor is it required for the fail2ban package
+
 ## 5.0.8 - *2024-05-02*
 
 ## 5.0.7 - *2024-05-02*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of the yum-epel cookbook.
 
 ## Unreleased
 
-- Amazon Linux 2023 does not officially support EPEL nor is it required for the fail2ban package
+- Amazon Linux 2023 does not officially support EPEL
 
 ## 5.0.8 - *2024-05-02*
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default['yum-epel']['repos'] =
         ),
     },
     'amazon' => {
+      '>= 2023' => [],
       'default' =>
         %w(
           epel

--- a/attributes/epel-next.rb
+++ b/attributes/epel-next.rb
@@ -5,6 +5,16 @@ default['yum']['epel-next']['mirrorlist'] =
   "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-next-#{yum_epel_release}&arch=$basearch"
 default['yum']['epel-next']['gpgkey'] =
   "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{yum_epel_release}"
-default['yum']['epel-next']['enabled'] = true
+default['yum']['epel-next']['enabled'] = value_for_platform(
+  'amazon' => {
+    '>= 2023' => false,
+  },
+  'default' => true
+)
 default['yum']['epel-next']['managed'] = true
-default['yum']['epel-next']['make_cache'] = true
+default['yum']['epel-next']['make_cache'] = value_for_platform(
+  'amazon' => {
+    '>= 2023' => false,
+  },
+  'default' => true
+)

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -14,6 +14,16 @@ else
     "https://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{yum_epel_release}&arch=$basearch"
   default['yum']['epel']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{yum_epel_release}"
 end
-default['yum']['epel']['enabled'] = true
+default['yum']['epel']['enabled'] = value_for_platform(
+  'amazon' => {
+    '>= 2023' => false,
+  },
+  'default' => true
+)
 default['yum']['epel']['managed'] = true
-default['yum']['epel']['make_cache'] = true
+default['yum']['epel']['make_cache'] = value_for_platform(
+  'amazon' => {
+    '>= 2023' => false,
+  },
+  'default' => true
+)


### PR DESCRIPTION
# Description

Disable EPEL for Amazon Linux 2023 since [it does not officially support EPEL](https://docs.aws.amazon.com/linux/al2023/ug/epel.html).

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
